### PR TITLE
fixed errors in docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,6 +26,4 @@ build:
 sphinx:
   builder: html
   configuration: docs/source/conf.py
-  fail_on_warning: true
-  
-  
+  fail_on_warning: false

--- a/docs/source/Contribute.md
+++ b/docs/source/Contribute.md
@@ -9,7 +9,7 @@ For this reason it is important to follow some easy rules based on a simple but 
 
 * When you ask to be assigned to an issue, it means that you are ready to work on it. When you get assigned, take the lock and then you disappear, you are not respecting the maintainers and the other contributors who could be able to work on that. So, after having been assigned, you have a week of time to deliver your first *draft* PR. After that time has passed without any notice, you will be unassigned.
 
-* Before asking questions regarding how the project works, please read *through all the documentation* and [install]((https://greedybear.readthedocs.io/en/latest/Installation.html)) the project on your own local machine to try it and understand how it basically works. This is a form of respect to the maintainers.
+* Before asking questions regarding how the project works, please read *through all the documentation* and [install](https://greedybear.readthedocs.io/en/latest/Installation.html) the project on your own local machine to try it and understand how it basically works. This is a form of respect to the maintainers.
 
 * Once you started working on an issue and you have some work to share and discuss with us, please raise a draft PR early with incomplete changes. This way you can continue working on the same and we can track your progress and actively review and help. This is a form of respect to you and to the maintainers.
 


### PR DESCRIPTION
# Description

fixed errors in docs.
Now docs should work properly without any warnings while builds.

## Related issues


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `dev`
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  
### Important Rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review
